### PR TITLE
DEN-7429: use space created_at and filter space_type=type

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,30 @@ be filtered via space tags.
 
 Configurable to calculate and store DAILY or MONTHLY peaks.
 
-## Setup (Requires python 3)
-`pip install -r requirements.txt`
+## Setup (Requires Python3)
+```bash
+pip install -r requirements.txt
+```
 
-## Running
+#### Usage
+```bash
+density_peaks.py [-h] -s START_DATE -e END_DATE -t TOKEN [-p PEAK_TYPE]
+                        [--tag TAG]
 
-`python density_peaks.py [ARGS]`
-
-#### Args
-- `-s --start-date`: Start date (local) of peaks query. Format: YYYY-MM-DD
-- `-e --end-date`: Start date (local) of peaks query. Format: YYYY-MM-DD
-- `-p --peak-type`: Peak type (row size) - DAILY (default) or MONTHLY
-- `-t --token`: Density API token.
-- `--tag`: Optional
+optional arguments:
+  -h, --help            show this help message and exit
+  -s START_DATE, --start-date START_DATE
+                        Start date (local) of peaks query: YYYY-MM-DD
+  -e END_DATE, --end-date END_DATE
+                        End date (local) of peaks query. Format: YYYY-MM-DD
+  -t TOKEN, --token TOKEN
+                        Density API token (read-only preferred)
+  -p PEAK_TYPE, --peak-type PEAK_TYPE
+                        Peak type (DAILY or MONTHLY)
+  --tag TAG             Filter Density spaces by tag name
+```
 
 #### Example
-`python density_peaks.py -s=2019-01-01 -e=2019-01-08 -p=DAILY -t={TOKEN} --tag=conference_room`
+```bash
+./density_peaks.py -s=2019-01-01 -e=2019-01-08 -p=DAILY -t=tok_123123123123123 --tag=conference_room
+```


### PR DESCRIPTION
New example output showing start times being changed to the space create or a space being skipped with notice when it was created after the selected range:
```
./density_peaks.py --token=tok_blahsdfjkds -s 2018-01-01 -e 2018-12-31
Pulling counts for space: Ben's Home Office from 2018-04-16 17:00:00.786000 to 2019-01-01 00:00:00
Pulling counts for space: CoreNet 2018 from 2018-10-14 14:28:31.782000 to 2019-01-01 00:00:00
Pulling counts for space: Density Event - SF from 2018-10-14 14:28:31.782000 to 2019-01-01 00:00:00
Pulling counts for space: Gus's House from 2018-12-06 15:12:21.573000 to 2019-01-01 00:00:00
Pulling counts for space: Gus's Kitchen from 2018-12-06 15:12:21.573000 to 2019-01-01 00:00:00
Skiping Roberto Test Space 3 because it was created too recently (2019-01-03 16:20:01.530000+00:00)
.
.
.
```

Cleaned up `--help`, made some params required and some "pythonic" idiomatic changes as well.